### PR TITLE
Handle varying download url names/formats and archs

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -30,14 +30,32 @@ install_kubeseal() {
   rm -f $binary_path 2>/dev/null || true
 
   echo "Copying binary"
-  cp "${tmp_download_dir}/kubeseal-${platform}" ${binary_path}
+  case "$download_path" in
+    *.tar.gz)
+      tar -x -C "$tmp_download_dir" -f "$download_path" kubeseal
+      cp "${tmp_download_dir}/kubeseal" ${binary_path}
+      ;;
+    *)
+      cp "${download_path}" ${binary_path}
+      ;;
+  esac
+
   chmod +x ${binary_path}
 }
 
 get_filename() {
   local platform="$2"
+  local version="$1"
+  local minor_version=$(echo "$version" | sed -E 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/')
 
-  echo "kubeseal-${platform}"
+  if [ "$minor_version" -le 16 ]; then
+    echo "kubeseal-${platform}"
+  elif [ "$version" = "0.17.0" ]; then
+    local Platform="$(echo ${platform:0:1} | tr '[:lower:]' '[:upper:]')${platform:1}"
+    echo "sealed-secrets_${version}_${Platform/-/_}.tar.gz"
+  else
+    echo "kubeseal-${version}-${platform}.tar.gz"
+  fi
 }
 
 get_download_url() {

--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,9 @@ install_kubeseal() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')-amd64"
+  local os="$(uname | tr '[:upper:]' '[:lower:]')"
+  local arch="$(uname -m | sed -e 's/x86_64/amd64/')"
+  local platform="$os-$arch"
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/kubeseal"
   local download_url=$(get_download_url $version $platform)

--- a/bin/install
+++ b/bin/install
@@ -9,10 +9,9 @@ install_kubeseal() {
   local install_path=$3
   local os="$(uname | tr '[:upper:]' '[:lower:]')"
   local arch="$(uname -m | sed -e 's/x86_64/amd64/')"
-  local platform="$os-$arch"
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/kubeseal"
-  local download_url=$(get_download_url $version $platform)
+  local download_url=$(get_download_url $version $os $arch)
 
   if [ "$TMPDIR" = "" ]; then
     local tmp_download_dir=$(mktemp -d -t kubeseal_XXXXXX)
@@ -20,7 +19,7 @@ install_kubeseal() {
     local tmp_download_dir=$TMPDIR
   fi
 
-  local download_path="$tmp_download_dir/$(get_filename $version $platform)"
+  local download_path="$tmp_download_dir/$(get_filename $version $os $arch)"
 
   echo "Downloading kubeseal from ${download_url} to ${download_path}"
   curl -f -Lo $download_path $download_url
@@ -46,24 +45,26 @@ install_kubeseal() {
 }
 
 get_filename() {
-  local platform="$2"
   local version="$1"
+  local os="$2"
+  local arch="$3"
   local minor_version=$(echo "$version" | sed -E 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/')
 
   if [ "$minor_version" -le 16 ]; then
-    echo "kubeseal-${platform}"
+    echo "kubeseal-${os}-amd64"
   elif [ "$version" = "0.17.0" ]; then
-    local Platform="$(echo ${platform:0:1} | tr '[:lower:]' '[:upper:]')${platform:1}"
-    echo "sealed-secrets_${version}_${Platform/-/_}.tar.gz"
+    local Os="$(echo ${os:0:1} | tr '[:lower:]' '[:upper:]')${os:1}"
+    echo "sealed-secrets_${version}_${Os}_${arch}.tar.gz"
   else
-    echo "kubeseal-${version}-${platform}.tar.gz"
+    echo "kubeseal-${version}-${os}-${arch}.tar.gz"
   fi
 }
 
 get_download_url() {
   local version="$1"
-  local platform="$2"
-  local filename="$(get_filename $version $platform)"
+  local os="$2"
+  local arch="$3"
+  local filename="$(get_filename $version $os $arch)"
 
   echo "https://github.com/bitnami-labs/sealed-secrets/releases/download/v${version}/${filename}"
 }

--- a/bin/list-all
+++ b/bin/list-all
@@ -13,6 +13,6 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-# Fetch all tag names, and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+# Fetch all tag names of format "vX.Y.Z" or "X.Y.Z", and get only second column. Then remove all unnecesary characters.
+versions=$(eval $cmd | grep -oE "tag_name\": *\"v?\d+\.\d+\.\d+\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
These changes:

1. Handles tar.gz in versions >= 0.17.0
2. Handles the special download url name in version 0.17.0 (it deviates from all other)
3. Uses amd64 for versions < 0.17.0 (as before) but arm64 if relevant for versions >= 0.17.0, e.g. for M1 Macs.

Tested on my own (amd64) Mac. Not tested on M1 Mac.