### PR TITLE
fix: fix list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-releases_path=https://api.github.com/repos/bitnami-labs/sealed-secrets/releases
-cmd="curl -s"
-if [ -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
-fi
-cmd="$cmd $releases_path"
-
 # stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
 function sort_versions() {
   sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' | \
@@ -14,5 +7,13 @@ function sort_versions() {
 }
 
 # Fetch all tag names of format "vX.Y.Z" or "X.Y.Z", and get only second column. Then remove all unnecesary characters.
-versions=$(eval $cmd | grep -oE "tag_name\": *\"v?\d+\.\d+\.\d+\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions=$(git ls-remote --tags --refs https://github.com/bitnami-labs/sealed-secrets.git |
+  # skip helm tags
+  grep -v helm |
+  # skip wrong tags in the repo
+  grep -v sealed-secrets |
+  grep -o 'refs/tags/.*' |
+  cut -d/ -f3- |
+  sed 's/^v//' |
+  sort_versions)
 echo $versions


### PR DESCRIPTION
I'm having the following issue which this PR should fix:

```python
✔ Select versions to install · kubeseal@latest
/home/bellini/.local/share/rtx/plugins/kubeseal/bin/install: line 53: [: latest: integer expression expected
/home/bellini/.local/share/rtx/plugins/kubeseal/bin/install: line 53: [: latest: integer expression expected
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     9    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
/home/bellini/.local/share/rtx/plugins/kubeseal/bin/install: line 53: [: latest: integer expression expected
/home/bellini/.local/share/rtx/plugins/kubeseal/bin/install: line 53: [: latest: integer expression expected
Downloading kubeseal from https://github.com/bitnami-labs/sealed-secrets/releases/download/vlatest/kubeseal-latest-linux-amd64.tar.gz to /tmp/kubeseal_vcvdg0/kubeseal-latest-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     9    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
rtx kubeseal@latest Downloading kubeseal from https://github.com/bitnami-labs/sealed-secrets/releases/download/vlatest/kubeseal-latest-linux-amd64.tar.gz to /tmp/kubeseal_vcvdg0/kubeseal-latest-linux-amd64.tar.gz                     ✗ 0s rtx ~/.local/share/rtx/plugins/kubeseal/bin/install exited with non-zero status: exit code 22
rtx Run with RTX_DEBUG=1 for more information
```